### PR TITLE
fix: liquid caps calculation on 32-length addresses

### DIFF
--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -262,6 +262,7 @@ func NewAppKeeper(
 	appKeepers.LiquidKeeper = liquidkeeper.NewKeeper(
 		appCodec,
 		runtime.NewKVStoreService(appKeepers.keys[liquidtypes.StoreKey]),
+		runtime.NewTransientStoreService(appKeepers.tkeys[liquidtypes.TStoreKey]),
 		appKeepers.AccountKeeper,
 		appKeepers.BankKeeper,
 		appKeepers.StakingKeeper,

--- a/app/keepers/keys.go
+++ b/app/keepers/keys.go
@@ -66,7 +66,7 @@ func (appKeepers *AppKeepers) GenerateKeys() {
 	)
 
 	// Define transient store keys
-	appKeepers.tkeys = storetypes.NewTransientStoreKeys(paramstypes.TStoreKey)
+	appKeepers.tkeys = storetypes.NewTransientStoreKeys(paramstypes.TStoreKey, liquidtypes.TStoreKey)
 }
 
 func (appKeepers *AppKeepers) GetKVStoreKey() map[string]*storetypes.KVStoreKey {

--- a/tests/integration/test_common.go
+++ b/tests/integration/test_common.go
@@ -59,6 +59,9 @@ func initFixture(tb testing.TB) *fixture {
 	keys := storetypes.NewKVStoreKeys(
 		authtypes.StoreKey, banktypes.StoreKey, distributiontypes.StoreKey, stakingtypes.StoreKey, liquidtypes.StoreKey,
 	)
+	tkeys := storetypes.NewTransientStoreKeys(
+		liquidtypes.TStoreKey,
+	)
 	cdc := moduletestutil.MakeTestEncodingConfig(auth.AppModuleBasic{}, staking.AppModuleBasic{}, vesting.AppModuleBasic{}).Codec
 
 	logger := log.NewTestLogger(tb)
@@ -103,7 +106,7 @@ func initFixture(tb testing.TB) *fixture {
 		addresscodec.NewBech32Codec(sdk.GetConfig().GetBech32ConsensusAddrPrefix()))
 	distributionKeeper := distributionkeeper.NewKeeper(cdc, runtime.NewKVStoreService(keys[distributiontypes.
 		StoreKey]), accountKeeper, bankKeeper, stakingKeeper, distributiontypes.ModuleName, authority.String())
-	liquidKeeper := liquidkeeper.NewKeeper(cdc, runtime.NewKVStoreService(keys[liquidtypes.StoreKey]), accountKeeper,
+	liquidKeeper := liquidkeeper.NewKeeper(cdc, runtime.NewKVStoreService(keys[liquidtypes.StoreKey]), runtime.NewTransientStoreService(tkeys[liquidtypes.TStoreKey]), accountKeeper,
 		bankKeeper, stakingKeeper, distributionKeeper, authority.String())
 
 	authModule := auth.NewAppModule(cdc, accountKeeper, authsims.RandomGenesisAccounts, nil)

--- a/x/liquid/keeper/hooks.go
+++ b/x/liquid/keeper/hooks.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	sdkmath "cosmossdk.io/math"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
@@ -14,13 +13,26 @@ import (
 // Wrapper struct
 type Hooks struct {
 	k Keeper
+
+	//CONTRACT: assumes serial calling of hooks. (no parallel msg/tx/block processing)
+	// while staking(delegate) -> hooks are called in either of these orders:
+	// BeforeDelegationCreated -> AfterDelegationModified
+	// BeforeDelegationModified -> AfterDelegationModified
+	// while unstaking (undelegate) -> hooks are called either of these orders:
+	// BeforeDelegationModified -> BeforeDelegationRemoved
+	// BeforeDelegationModified -> AfterDelegationModified
+
+	predelegation *stakingtypes.Delegation
 }
 
 var _ stakingtypes.StakingHooks = Hooks{}
 
 // Create new liquid hooks
 func (k Keeper) Hooks() Hooks {
-	return Hooks{k}
+	return Hooks{
+		k:             k,
+		predelegation: nil,
+	}
 }
 
 // initialize liquid validator record
@@ -37,15 +49,84 @@ func (h Hooks) AfterValidatorRemoved(ctx context.Context, _ sdk.ConsAddress, val
 	return h.k.RemoveLiquidValidator(ctx, valAddr)
 }
 
-func (h Hooks) BeforeDelegationCreated(_ context.Context, _ sdk.AccAddress, _ sdk.ValAddress) error {
+func (h Hooks) BeforeDelegationCreated(_ context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
+	if h.k.DelegatorIsLiquidStaker(delAddr) {
+		if h.predelegation != nil {
+			return types.ErrPreHookIsNotNil
+		}
+
+		h.predelegation = &stakingtypes.Delegation{
+			DelegatorAddress: delAddr.String(),
+			ValidatorAddress: valAddr.String(),
+			Shares:           sdkmath.LegacyZeroDec(),
+		}
+	}
 	return nil
 }
 
-func (h Hooks) BeforeDelegationSharesModified(_ context.Context, _ sdk.AccAddress, _ sdk.ValAddress) error {
+func (h Hooks) BeforeDelegationSharesModified(ctx context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
+	if h.k.DelegatorIsLiquidStaker(delAddr) {
+		if h.predelegation != nil {
+			return types.ErrPreHookIsNotNil
+		}
+
+		predel, err := h.k.stakingKeeper.GetDelegation(ctx, delAddr, valAddr)
+		if err != nil {
+			return err
+		}
+		h.predelegation = &predel
+	}
 	return nil
 }
 
-func (h Hooks) AfterDelegationModified(_ context.Context, _ sdk.AccAddress, _ sdk.ValAddress) error {
+func (h Hooks) AfterDelegationModified(ctx context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
+	if h.k.DelegatorIsLiquidStaker(delAddr) {
+		if h.predelegation == nil {
+			return types.ErrPreHookIsNil
+		}
+		del, err := h.k.stakingKeeper.GetDelegation(ctx, delAddr, valAddr)
+		if err != nil {
+			return err
+		}
+		if del.Shares.GT(h.predelegation.Shares) {
+			// is bonding
+			diffShares := del.Shares.Sub(h.predelegation.Shares)
+			validator, err := h.k.stakingKeeper.GetValidator(ctx, valAddr)
+			if err != nil {
+				return err
+			}
+			diffTokens := validator.TokensFromSharesTruncated(del.Shares).TruncateInt().
+				Sub(validator.TokensFromSharesTruncated(h.predelegation.Shares).TruncateInt())
+			if err := h.k.SafelyIncreaseTotalLiquidStakedTokens(ctx, diffTokens, true); err != nil {
+				return err
+			}
+			_, err = h.k.SafelyIncreaseValidatorLiquidShares(ctx, valAddr, diffShares, true)
+			if err != nil {
+				return err
+			}
+		} else if del.Shares.LT(h.predelegation.Shares) {
+			// is unbonding
+			diffShares := h.predelegation.Shares.Sub(del.Shares)
+			validator, err := h.k.stakingKeeper.GetValidator(ctx, valAddr)
+			if err != nil {
+				return err
+			}
+			diffTokens := validator.TokensFromSharesTruncated(h.predelegation.Shares).TruncateInt().
+				Sub(validator.TokensFromSharesTruncated(del.Shares).TruncateInt())
+			if err := h.k.DecreaseTotalLiquidStakedTokens(ctx, diffTokens); err != nil {
+				return err
+			}
+			_, err = h.k.DecreaseValidatorLiquidShares(ctx, valAddr, diffShares)
+			if err != nil {
+				return err
+			}
+		} else {
+			return types.ErrInvalidHookInvocation
+		}
+
+		// reset prehook
+		h.predelegation = nil
+	}
 	return nil
 }
 
@@ -84,7 +165,28 @@ func (h Hooks) AfterValidatorBeginUnbonding(_ context.Context, _ sdk.ConsAddress
 	return nil
 }
 
-func (h Hooks) BeforeDelegationRemoved(_ context.Context, _ sdk.AccAddress, _ sdk.ValAddress) error {
+func (h Hooks) BeforeDelegationRemoved(ctx context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
+	if h.k.DelegatorIsLiquidStaker(delAddr) {
+		if h.predelegation == nil {
+			return types.ErrPreHookIsNil
+		}
+		// is unbonding.
+		validator, err := h.k.stakingKeeper.GetValidator(ctx, valAddr)
+		if err != nil {
+			return err
+		}
+		tokens := validator.TokensFromSharesTruncated(h.predelegation.Shares).TruncateInt()
+		if err := h.k.DecreaseTotalLiquidStakedTokens(ctx, tokens); err != nil {
+			return err
+		}
+		_, err = h.k.DecreaseValidatorLiquidShares(ctx, valAddr, h.predelegation.Shares)
+		if err != nil {
+			return err
+		}
+
+		// reset prehook
+		h.predelegation = nil
+	}
 	return nil
 }
 
@@ -95,3 +197,352 @@ func (h Hooks) AfterUnbondingInitiated(_ context.Context, _ uint64) error {
 func (h Hooks) BeforeTokenizeShareRecordRemoved(_ context.Context, _ uint64) error {
 	return nil
 }
+
+////
+//// trimmed imports
+//import (
+//"context"
+//"crypto/sha256"
+//"encoding/binary"
+//"fmt"
+//
+//sdk "github.com/cosmos/cosmos-sdk/types"
+//"github.com/cosmos/cosmos-sdk/codec"
+//stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+//)
+
+// HookKind constants
+//const (
+//	HookCreate        = "create"
+//	HookSharesMod     = "shares_modified"
+//	HookRemove        = "remove"
+//	HookRedelegateOut = "redelegate_out" // optional
+//)
+//
+//// DelegationEvent is the pre-state snapshot pushed on Before*
+//type DelegationEvent struct {
+//	EventID            uint64
+//	HookKind           string
+//	Delegator          sdk.AccAddress
+//	Validator          sdk.ValAddress
+//	PreShares          sdk.Dec
+//	PreValidatorTokens sdk.Dec // validator tokens pre-change (to compute tokens delta safely)
+//	PreValidatorShares sdk.Dec // validator delegator shares pre-change
+//}
+//
+//// Keeper (partial) -- you must provide cdc, tKey, stakingKeeper, and any cap params
+////type Keeper struct {
+////	cdc           codec.BinaryCodec
+////	tKey          sdk.TransientStoreKey
+////	stakingKeeper StakingKeeper
+////	// per-validator cap config (example)
+////	validatorCap sdk.Int // maximum tokens allowed per validator per tx (for example)
+////}
+//
+////// StakingKeeper interface subset
+////type StakingKeeper interface {
+////	GetDelegation(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) (stakingtypes.Delegation, bool)
+////	GetValidator(ctx sdk.Context, valAddr sdk.ValAddress) (stakingtypes.Validator, bool)
+////}
+//
+//// prefixes
+//var (
+//	prefixStack   = []byte{0x01} // stack per ns||delegator||validator
+//	prefixEvent   = []byte{0x02} // store event by ns||eventID
+//	prefixCounter = []byte{0x03} // per-ns counter for eventID
+//	prefixAccVal  = []byte{0x04} // per-ns per-validator accumulator (sdk.Int bytes)
+//	prefixExecCtr = []byte{0x05} // per-block exec counter fallback
+//)
+//
+//// txNsBytes get namespace for current execution (tx-scoped when possible)
+//func (k Keeper) txNsBytes(ctx sdk.Context) []byte {
+//	txBytes := ctx.TxBytes()
+//	if len(txBytes) > 0 {
+//		h := sha256.Sum256(txBytes)
+//		return h[:]
+//	}
+//	// fallback: use block height + block time + a per-block transient exec counter
+//	store := ctx.TransientStore(k.tKey)
+//	bh := ctx.BlockHeight()
+//	bt := ctx.BlockTime().UnixNano()
+//
+//	// exec counter per block to distinguish multiple begin/end calls across modules
+//	ctrKey := append(prefixExecCtr, []byte(fmt.Sprintf("|%d|", bh))...)
+//	bz := store.Get(ctrKey)
+//	var ctr uint64
+//	if len(bz) >= 8 {
+//		ctr = binary.BigEndian.Uint64(bz)
+//	}
+//	ctr++
+//	nb := make([]byte, 8)
+//	binary.BigEndian.PutUint64(nb, ctr)
+//	store.Set(ctrKey, nb)
+//
+//	keyStr := fmt.Sprintf("bh:%d|bt:%d|ctr:%d", bh, bt, ctr)
+//	h := sha256.Sum256([]byte(keyStr))
+//	return h[:]
+//}
+//
+//// nextEventID increments per-ns counter and returns id
+//func (k Keeper) nextEventID(ctx sdk.Context) uint64 {
+//	store := ctx.TransientStore(k.tKey)
+//	ns := k.txNsBytes(ctx)
+//	key := append(prefixCounter, ns...)
+//	bz := store.Get(key)
+//	var ctr uint64
+//	if len(bz) >= 8 {
+//		ctr = binary.BigEndian.Uint64(bz)
+//	}
+//	ctr++
+//	nb := make([]byte, 8)
+//	binary.BigEndian.PutUint64(nb, ctr)
+//	store.Set(key, nb)
+//	return ctr
+//}
+//
+//func stackKey(ns []byte, del sdk.AccAddress, val sdk.ValAddress) []byte {
+//	k := make([]byte, 0, 1+len(ns)+1+len(del)+1+len(val))
+//	k = append(k, prefixStack...)
+//	k = append(k, ns...)
+//	k = append(k, 0x00)
+//	k = append(k, del.Bytes()...)
+//	k = append(k, 0x00)
+//	k = append(k, val.Bytes()...)
+//	return k
+//}
+//func eventKey(ns []byte, eventID uint64) []byte {
+//	k := make([]byte, 0, 1+len(ns)+8)
+//	k = append(k, prefixEvent...)
+//	k = append(k, ns...)
+//	bz := make([]byte, 8)
+//	binary.BigEndian.PutUint64(bz, eventID)
+//	k = append(k, bz...)
+//	return k
+//}
+//func accValKey(ns []byte, val sdk.ValAddress) []byte {
+//	k := make([]byte, 0, 1+len(ns)+len(val))
+//	k = append(k, prefixAccVal...)
+//	k = append(k, ns...)
+//	k = append(k, 0x00)
+//	k = append(k, val.Bytes()...)
+//	return k
+//}
+//
+//// pushEvent: push eventID onto stack for (del,val) (LIFO behavior: append at end)
+//func (k Keeper) pushEvent(ctx sdk.Context, del sdk.AccAddress, val sdk.ValAddress, event DelegationEvent) {
+//	store := ctx.TransientStore(k.tKey)
+//	ns := k.txNsBytes(ctx)
+//	// store event by id
+//	ekey := eventKey(ns, event.EventID)
+//	bz := k.cdc.MustMarshal(&event)
+//	store.Set(ekey, bz)
+//
+//	// append id to stack
+//	sk := stackKey(ns, del, val)
+//	old := store.Get(sk)
+//	idbz := make([]byte, 8)
+//	binary.BigEndian.PutUint64(idbz, event.EventID)
+//	new := append(old, idbz...)
+//	store.Set(sk, new)
+//}
+//
+//// popEvent: pop the topmost event id for (del,val). LIFO: read last 8 bytes.
+//func (k Keeper) popEvent(ctx sdk.Context, del sdk.AccAddress, val sdk.ValAddress) (DelegationEvent, bool) {
+//	var ev DelegationEvent
+//	store := ctx.TransientStore(k.tKey)
+//	ns := k.txNsBytes(ctx)
+//	sk := stackKey(ns, del, val)
+//	old := store.Get(sk)
+//	if len(old) < 8 {
+//		return ev, false
+//	}
+//	// take last 8 bytes
+//	lastIdx := len(old) - 8
+//	id := binary.BigEndian.Uint64(old[lastIdx:])
+//	// trim
+//	new := old[:lastIdx]
+//	if len(new) == 0 {
+//		store.Delete(sk)
+//	} else {
+//		store.Set(sk, new)
+//	}
+//	// load event
+//	ekey := eventKey(ns, id)
+//	bz := store.Get(ekey)
+//	if len(bz) == 0 {
+//		return ev, false
+//	}
+//	k.cdc.MustUnmarshal(bz, &ev)
+//	// delete event entry now or after processing
+//	store.Delete(ekey)
+//	return ev, true
+//}
+//
+//// accValAdd: accumulate token delta to per-validator accumulator (sdk.Int)
+//func (k Keeper) accValAdd(ctx sdk.Context, val sdk.ValAddress, delta sdk.Int) {
+//	store := ctx.TransientStore(k.tKey)
+//	ns := k.txNsBytes(ctx)
+//	ak := accValKey(ns, val)
+//	old := store.Get(ak)
+//	var cur sdk.Int
+//	if len(old) > 0 {
+//		cur.Unmarshal([]byte(old))
+//	} else {
+//		cur = sdk.ZeroInt()
+//	}
+//	cur = cur.Add(delta)
+//	bz, _ := cur.Marshal()
+//	store.Set(ak, bz)
+//}
+//func (k Keeper) accValGet(ctx sdk.Context, val sdk.ValAddress) sdk.Int {
+//	store := ctx.TransientStore(k.tKey)
+//	ns := k.txNsBytes(ctx)
+//	ak := accValKey(ns, val)
+//	old := store.Get(ak)
+//	var cur sdk.Int
+//	if len(old) > 0 {
+//		cur.Unmarshal([]byte(old))
+//	} else {
+//		cur = sdk.ZeroInt()
+//	}
+//	return cur
+//}
+//
+//// --- Hooks implementation ---
+//
+//type Hooks struct {
+//	k Keeper
+//}
+//
+//var _ stakingtypes.StakingHooks = Hooks{}
+//
+//// BeforeDelegationCreated
+//func (h Hooks) BeforeDelegationCreated(ctx context.Context, del sdk.AccAddress, val sdk.ValAddress) error {
+//	sdkCtx := sdk.UnwrapSDKContext(ctx)
+//
+//	// take snapshot
+//	preShares := sdk.ZeroDec()
+//	if delg, found := h.k.stakingKeeper.GetDelegation(sdkCtx, del, val); found {
+//		preShares = delg.Shares
+//	}
+//	preValTokens := sdk.ZeroDec()
+//	preValShares := sdk.ZeroDec()
+//	if v, ok := h.k.stakingKeeper.GetValidator(sdkCtx, val); ok {
+//		preValTokens = v.Tokens.ToDec()
+//		preValShares = v.DelegatorShares
+//	}
+//
+//	id := h.k.nextEventID(sdkCtx)
+//	ev := DelegationEvent{
+//		EventID:            id,
+//		HookKind:           HookCreate,
+//		Delegator:          del,
+//		Validator:          val,
+//		PreShares:          preShares,
+//		PreValidatorTokens: preValTokens,
+//		PreValidatorShares: preValShares,
+//	}
+//	h.k.pushEvent(sdkCtx, del, val, ev)
+//	return nil
+//}
+//
+//// BeforeDelegationSharesModified
+//func (h Hooks) BeforeDelegationSharesModified(ctx context.Context, del sdk.AccAddress, val sdk.ValAddress) error {
+//	sdkCtx := sdk.UnwrapSDKContext(ctx)
+//	preShares := sdk.ZeroDec()
+//	if delg, found := h.k.stakingKeeper.GetDelegation(sdkCtx, del, val); found {
+//		preShares = delg.Shares
+//	}
+//	preValTokens := sdk.ZeroDec()
+//	preValShares := sdk.ZeroDec()
+//	if v, ok := h.k.stakingKeeper.GetValidator(sdkCtx, val); ok {
+//		preValTokens = v.Tokens.ToDec()
+//		preValShares = v.DelegatorShares
+//	}
+//	id := h.k.nextEventID(sdkCtx)
+//	ev := DelegationEvent{
+//		EventID:            id,
+//		HookKind:           HookSharesMod,
+//		Delegator:          del,
+//		Validator:          val,
+//		PreShares:          preShares,
+//		PreValidatorTokens: preValTokens,
+//		PreValidatorShares: preValShares,
+//	}
+//	h.k.pushEvent(sdkCtx, del, val, ev)
+//	return nil
+//}
+//
+//// BeforeDelegationRemoved
+//func (h Hooks) BeforeDelegationRemoved(ctx context.Context, del sdk.AccAddress, val sdk.ValAddress) error {
+//	sdkCtx := sdk.UnwrapSDKContext(ctx)
+//	preShares := sdk.ZeroDec()
+//	if delg, found := h.k.stakingKeeper.GetDelegation(sdkCtx, del, val); found {
+//		preShares = delg.Shares
+//	}
+//	preValTokens := sdk.ZeroDec()
+//	preValShares := sdk.ZeroDec()
+//	if v, ok := h.k.stakingKeeper.GetValidator(sdkCtx, val); ok {
+//		preValTokens = v.Tokens.ToDec()
+//		preValShares = v.DelegatorShares
+//	}
+//	id := h.k.nextEventID(sdkCtx)
+//	ev := DelegationEvent{
+//		EventID:            id,
+//		HookKind:           HookRemove,
+//		Delegator:          del,
+//		Validator:          val,
+//		PreShares:          preShares,
+//		PreValidatorTokens: preValTokens,
+//		PreValidatorShares: preValShares,
+//	}
+//	h.k.pushEvent(sdkCtx, del, val, ev)
+//	return nil
+//}
+//
+//// AfterDelegationModified
+//func (h Hooks) AfterDelegationModified(ctx context.Context, del sdk.AccAddress, val sdk.ValAddress) error {
+//	sdkCtx := sdk.UnwrapSDKContext(ctx)
+//
+//	ev, ok := h.k.popEvent(sdkCtx, del, val)
+//	if !ok {
+//		// no matching before snapshot for this (del,val) — safe fallback: no-op
+//		return nil
+//	}
+//
+//	// load post-shares
+//	postShares := sdk.ZeroDec()
+//	if delg, found := h.k.stakingKeeper.GetDelegation(sdkCtx, del, val); found {
+//		postShares = delg.Shares
+//	}
+//
+//	// compute deltaShares
+//	deltaShares := postShares.Sub(ev.PreShares)
+//	if deltaShares.IsZero() {
+//		return nil
+//	}
+//
+//	// compute token delta using validator post-state (or pre-state)
+//	valObj, ok := h.k.stakingKeeper.GetValidator(sdkCtx, val)
+//	if !ok || valObj.DelegatorShares.IsZero() {
+//		// can't compute -> safe no-op
+//		return nil
+//	}
+//	// Use validator CURRENT tokens/shares (post-change) to derive token delta
+//	// tokenDelta = deltaShares * validator.Tokens / validator.DelegatorShares
+//	tokensDec := valObj.Tokens.ToDec()
+//	tokenDeltaDec := deltaShares.Mul(tokensDec).Quo(valObj.DelegatorShares)
+//	tokenDeltaInt := tokenDeltaDec.TruncateInt()
+//
+//	// accumulate per-validator (for cap checks)
+//	h.k.accValAdd(sdkCtx, val, tokenDeltaInt)
+//
+//	// If you want immediate abort on cap exceed:
+//	// total := h.k.accValGet(sdkCtx, val)
+//	// if total.GT(h.k.validatorCap) {
+//	//     return sdkerrors.Wrapf(..., "validator cap exceeded")
+//	// }
+//
+//	// otherwise just continue and finalize later (EndBlocker or after all hooks)
+//	return nil
+//}

--- a/x/liquid/keeper/hooks.go
+++ b/x/liquid/keeper/hooks.go
@@ -19,7 +19,7 @@ var (
 	// while unstaking (undelegate) -> hooks are called either of these orders:
 	// BeforeDelegationModified -> BeforeDelegationRemoved
 	// BeforeDelegationModified -> AfterDelegationModified
-
+	// TODO move to transient store in keeper
 	predelegation *stakingtypes.Delegation = nil
 )
 
@@ -53,10 +53,10 @@ func (h Hooks) AfterValidatorRemoved(ctx context.Context, _ sdk.ConsAddress, val
 
 func (h Hooks) BeforeDelegationCreated(_ context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
 	if h.k.DelegatorIsLiquidStaker(delAddr) {
-		if predelegation != nil {
-			return types.ErrPreHookIsNotNil
-		}
-
+		//if predelegation != nil {
+		//	return types.ErrPreHookIsNotNil
+		//}
+		// igore check for predelegation as it might have been set and errored out, can be added when the var is transient store
 		predelegation = &stakingtypes.Delegation{
 			DelegatorAddress: delAddr.String(),
 			ValidatorAddress: valAddr.String(),
@@ -68,10 +68,10 @@ func (h Hooks) BeforeDelegationCreated(_ context.Context, delAddr sdk.AccAddress
 
 func (h Hooks) BeforeDelegationSharesModified(ctx context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
 	if h.k.DelegatorIsLiquidStaker(delAddr) {
-		if predelegation != nil {
-			return types.ErrPreHookIsNotNil
-		}
-
+		//if predelegation != nil {
+		//	return types.ErrPreHookIsNotNil
+		//}
+		// igore check for predelegation as it might have been set and errored out, can be added when the var is transient store
 		predel, err := h.k.stakingKeeper.GetDelegation(ctx, delAddr, valAddr)
 		if err != nil {
 			return err
@@ -86,6 +86,8 @@ func (h Hooks) AfterDelegationModified(ctx context.Context, delAddr sdk.AccAddre
 		if predelegation == nil {
 			return types.ErrPreHookIsNil
 		}
+		// reset prehook
+		defer func() { predelegation = nil }()
 		del, err := h.k.stakingKeeper.GetDelegation(ctx, delAddr, valAddr)
 		if err != nil {
 			return err
@@ -125,9 +127,6 @@ func (h Hooks) AfterDelegationModified(ctx context.Context, delAddr sdk.AccAddre
 		} else {
 			return types.ErrInvalidHookInvocation
 		}
-
-		// reset prehook
-		predelegation = nil
 	}
 	return nil
 }
@@ -172,6 +171,8 @@ func (h Hooks) BeforeDelegationRemoved(ctx context.Context, delAddr sdk.AccAddre
 		if predelegation == nil {
 			return types.ErrPreHookIsNil
 		}
+		// reset prehook
+		defer func() { predelegation = nil }()
 		// is unbonding.
 		validator, err := h.k.stakingKeeper.GetValidator(ctx, valAddr)
 		if err != nil {

--- a/x/liquid/keeper/hooks.go
+++ b/x/liquid/keeper/hooks.go
@@ -53,7 +53,7 @@ func (h Hooks) BeforeDelegationCreated(ctx context.Context, delAddr sdk.AccAddre
 		preDelegationChangeData, err := h.k.GetTransientHookDelegationData(ctx)
 		if err != nil || preDelegationChangeData != nil {
 			// ignore returning err for preDelegationChangeData as it might have been set and errored out
-			h.k.Logger(ctx).Error("%v: TransientKVStore if not empty, some actions might need cacheCtx usage %v, %v", types.ErrPreHookIsNotNil, preDelegationChangeData, err)
+			h.k.Logger(ctx).Error("transientKVStore if not empty, some actions might need cacheCtx usage", "error-type", types.ErrPreHookIsNotNil, "error", err, "delegation-data", preDelegationChangeData)
 		}
 
 		preDelegationChangeData = &stakingtypes.Delegation{
@@ -75,7 +75,7 @@ func (h Hooks) BeforeDelegationSharesModified(ctx context.Context, delAddr sdk.A
 		preDelegationChangeData, err := h.k.GetTransientHookDelegationData(ctx)
 		if err != nil || preDelegationChangeData != nil {
 			// ignore returning err for preDelegationChangeData as it might have been set and errored out
-			h.k.Logger(ctx).Error("%v: TransientKVStore if not empty, some actions might need cacheCtx usage %v, %v", types.ErrPreHookIsNotNil, preDelegationChangeData, err)
+			h.k.Logger(ctx).Error("transientKVStore if not empty, some actions might need cacheCtx usage", "error-type", types.ErrPreHookIsNotNil, "error", err, "delegation-data", preDelegationChangeData)
 		}
 
 		predel, err := h.k.stakingKeeper.GetDelegation(ctx, delAddr, valAddr)

--- a/x/liquid/keeper/hooks.go
+++ b/x/liquid/keeper/hooks.go
@@ -10,9 +10,7 @@ import (
 	"github.com/cosmos/gaia/v24/x/liquid/types"
 )
 
-// Wrapper struct
-type Hooks struct {
-	k Keeper
+var (
 
 	//CONTRACT: assumes serial calling of hooks. (no parallel msg/tx/block processing)
 	// while staking(delegate) -> hooks are called in either of these orders:
@@ -22,7 +20,12 @@ type Hooks struct {
 	// BeforeDelegationModified -> BeforeDelegationRemoved
 	// BeforeDelegationModified -> AfterDelegationModified
 
-	predelegation *stakingtypes.Delegation
+	predelegation *stakingtypes.Delegation = nil
+)
+
+// Wrapper struct
+type Hooks struct {
+	k Keeper
 }
 
 var _ stakingtypes.StakingHooks = Hooks{}
@@ -30,8 +33,7 @@ var _ stakingtypes.StakingHooks = Hooks{}
 // Create new liquid hooks
 func (k Keeper) Hooks() Hooks {
 	return Hooks{
-		k:             k,
-		predelegation: nil,
+		k: k,
 	}
 }
 
@@ -51,11 +53,11 @@ func (h Hooks) AfterValidatorRemoved(ctx context.Context, _ sdk.ConsAddress, val
 
 func (h Hooks) BeforeDelegationCreated(_ context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
 	if h.k.DelegatorIsLiquidStaker(delAddr) {
-		if h.predelegation != nil {
+		if predelegation != nil {
 			return types.ErrPreHookIsNotNil
 		}
 
-		h.predelegation = &stakingtypes.Delegation{
+		predelegation = &stakingtypes.Delegation{
 			DelegatorAddress: delAddr.String(),
 			ValidatorAddress: valAddr.String(),
 			Shares:           sdkmath.LegacyZeroDec(),
@@ -66,7 +68,7 @@ func (h Hooks) BeforeDelegationCreated(_ context.Context, delAddr sdk.AccAddress
 
 func (h Hooks) BeforeDelegationSharesModified(ctx context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
 	if h.k.DelegatorIsLiquidStaker(delAddr) {
-		if h.predelegation != nil {
+		if predelegation != nil {
 			return types.ErrPreHookIsNotNil
 		}
 
@@ -74,29 +76,29 @@ func (h Hooks) BeforeDelegationSharesModified(ctx context.Context, delAddr sdk.A
 		if err != nil {
 			return err
 		}
-		h.predelegation = &predel
+		predelegation = &predel
 	}
 	return nil
 }
 
 func (h Hooks) AfterDelegationModified(ctx context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
 	if h.k.DelegatorIsLiquidStaker(delAddr) {
-		if h.predelegation == nil {
+		if predelegation == nil {
 			return types.ErrPreHookIsNil
 		}
 		del, err := h.k.stakingKeeper.GetDelegation(ctx, delAddr, valAddr)
 		if err != nil {
 			return err
 		}
-		if del.Shares.GT(h.predelegation.Shares) {
+		if del.Shares.GT(predelegation.Shares) {
 			// is bonding
-			diffShares := del.Shares.Sub(h.predelegation.Shares)
+			diffShares := del.Shares.Sub(predelegation.Shares)
 			validator, err := h.k.stakingKeeper.GetValidator(ctx, valAddr)
 			if err != nil {
 				return err
 			}
 			diffTokens := validator.TokensFromSharesTruncated(del.Shares).TruncateInt().
-				Sub(validator.TokensFromSharesTruncated(h.predelegation.Shares).TruncateInt())
+				Sub(validator.TokensFromSharesTruncated(predelegation.Shares).TruncateInt())
 			if err := h.k.SafelyIncreaseTotalLiquidStakedTokens(ctx, diffTokens, true); err != nil {
 				return err
 			}
@@ -104,14 +106,14 @@ func (h Hooks) AfterDelegationModified(ctx context.Context, delAddr sdk.AccAddre
 			if err != nil {
 				return err
 			}
-		} else if del.Shares.LT(h.predelegation.Shares) {
+		} else if del.Shares.LT(predelegation.Shares) {
 			// is unbonding
-			diffShares := h.predelegation.Shares.Sub(del.Shares)
+			diffShares := predelegation.Shares.Sub(del.Shares)
 			validator, err := h.k.stakingKeeper.GetValidator(ctx, valAddr)
 			if err != nil {
 				return err
 			}
-			diffTokens := validator.TokensFromSharesTruncated(h.predelegation.Shares).TruncateInt().
+			diffTokens := validator.TokensFromSharesTruncated(predelegation.Shares).TruncateInt().
 				Sub(validator.TokensFromSharesTruncated(del.Shares).TruncateInt())
 			if err := h.k.DecreaseTotalLiquidStakedTokens(ctx, diffTokens); err != nil {
 				return err
@@ -125,7 +127,7 @@ func (h Hooks) AfterDelegationModified(ctx context.Context, delAddr sdk.AccAddre
 		}
 
 		// reset prehook
-		h.predelegation = nil
+		predelegation = nil
 	}
 	return nil
 }
@@ -167,7 +169,7 @@ func (h Hooks) AfterValidatorBeginUnbonding(_ context.Context, _ sdk.ConsAddress
 
 func (h Hooks) BeforeDelegationRemoved(ctx context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
 	if h.k.DelegatorIsLiquidStaker(delAddr) {
-		if h.predelegation == nil {
+		if predelegation == nil {
 			return types.ErrPreHookIsNil
 		}
 		// is unbonding.
@@ -175,17 +177,17 @@ func (h Hooks) BeforeDelegationRemoved(ctx context.Context, delAddr sdk.AccAddre
 		if err != nil {
 			return err
 		}
-		tokens := validator.TokensFromSharesTruncated(h.predelegation.Shares).TruncateInt()
+		tokens := validator.TokensFromSharesTruncated(predelegation.Shares).TruncateInt()
 		if err := h.k.DecreaseTotalLiquidStakedTokens(ctx, tokens); err != nil {
 			return err
 		}
-		_, err = h.k.DecreaseValidatorLiquidShares(ctx, valAddr, h.predelegation.Shares)
+		_, err = h.k.DecreaseValidatorLiquidShares(ctx, valAddr, predelegation.Shares)
 		if err != nil {
 			return err
 		}
 
 		// reset prehook
-		h.predelegation = nil
+		predelegation = nil
 	}
 	return nil
 }

--- a/x/liquid/keeper/hooks.go
+++ b/x/liquid/keeper/hooks.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"context"
 
+	sdkerrors "cosmossdk.io/errors"
 	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
@@ -10,18 +11,14 @@ import (
 	"github.com/cosmos/gaia/v24/x/liquid/types"
 )
 
-var (
-
-	//CONTRACT: assumes serial calling of hooks. (no parallel msg/tx/block processing)
-	// while staking(delegate) -> hooks are called in either of these orders:
-	// BeforeDelegationCreated -> AfterDelegationModified
-	// BeforeDelegationModified -> AfterDelegationModified
-	// while unstaking (undelegate) -> hooks are called either of these orders:
-	// BeforeDelegationModified -> BeforeDelegationRemoved
-	// BeforeDelegationModified -> AfterDelegationModified
-	// TODO move to transient store in keeper
-	predelegation *stakingtypes.Delegation = nil
-)
+// CONTRACT: types.TStoreyKey, for updating validator-liquid-share and total-liquid-tokens
+// Assumes synchronous calling of hooks. (no parallel msg/tx/block processing)
+// while staking(delegate) -> hooks are called in either of these orders:
+// BeforeDelegationCreated -> AfterDelegationModified
+// BeforeDelegationModified -> AfterDelegationModified
+// while unstaking (undelegate) -> hooks are called either of these orders:
+// BeforeDelegationModified -> BeforeDelegationRemoved
+// BeforeDelegationModified -> AfterDelegationModified
 
 // Wrapper struct
 type Hooks struct {
@@ -51,56 +48,70 @@ func (h Hooks) AfterValidatorRemoved(ctx context.Context, _ sdk.ConsAddress, val
 	return h.k.RemoveLiquidValidator(ctx, valAddr)
 }
 
-func (h Hooks) BeforeDelegationCreated(_ context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
+func (h Hooks) BeforeDelegationCreated(ctx context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
 	if h.k.DelegatorIsLiquidStaker(delAddr) {
-		//if predelegation != nil {
-		//	return types.ErrPreHookIsNotNil
-		//}
-		// igore check for predelegation as it might have been set and errored out, can be added when the var is transient store
-		predelegation = &stakingtypes.Delegation{
+		preDelegationChangeData, err := h.k.GetTransientHookDelegationData(ctx)
+		if err != nil || preDelegationChangeData != nil {
+			// ignore returning err for preDelegationChangeData as it might have been set and errored out
+			h.k.Logger(ctx).Error("%v: TransientKVStore if not empty, some actions might need cacheCtx usage %v, %v", types.ErrPreHookIsNotNil, preDelegationChangeData, err)
+		}
+
+		preDelegationChangeData = &stakingtypes.Delegation{
 			DelegatorAddress: delAddr.String(),
 			ValidatorAddress: valAddr.String(),
 			Shares:           sdkmath.LegacyZeroDec(),
 		}
+		err = h.k.SetTransientHookDelegationData(ctx, preDelegationChangeData)
+		if err != nil {
+			return err
+		}
+
 	}
 	return nil
 }
 
 func (h Hooks) BeforeDelegationSharesModified(ctx context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
 	if h.k.DelegatorIsLiquidStaker(delAddr) {
-		//if predelegation != nil {
-		//	return types.ErrPreHookIsNotNil
-		//}
-		// igore check for predelegation as it might have been set and errored out, can be added when the var is transient store
+		preDelegationChangeData, err := h.k.GetTransientHookDelegationData(ctx)
+		if err != nil || preDelegationChangeData != nil {
+			// ignore returning err for preDelegationChangeData as it might have been set and errored out
+			h.k.Logger(ctx).Error("%v: TransientKVStore if not empty, some actions might need cacheCtx usage %v, %v", types.ErrPreHookIsNotNil, preDelegationChangeData, err)
+		}
+
 		predel, err := h.k.stakingKeeper.GetDelegation(ctx, delAddr, valAddr)
 		if err != nil {
 			return err
 		}
-		predelegation = &predel
+		err = h.k.SetTransientHookDelegationData(ctx, &predel)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }
 
 func (h Hooks) AfterDelegationModified(ctx context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
 	if h.k.DelegatorIsLiquidStaker(delAddr) {
-		if predelegation == nil {
-			return types.ErrPreHookIsNil
+		preDelegationChangeData, err := h.k.GetTransientHookDelegationData(ctx)
+		if err != nil || preDelegationChangeData == nil {
+			return sdkerrors.Wrapf(types.ErrPreHookIsNil, "err: %v, transientStoreData is empty, expected non-nil value", err)
 		}
+
 		// reset prehook
-		defer func() { predelegation = nil }()
+		defer func() { _ = h.k.SetTransientHookDelegationData(ctx, preDelegationChangeData) }()
 		del, err := h.k.stakingKeeper.GetDelegation(ctx, delAddr, valAddr)
 		if err != nil {
 			return err
 		}
-		if del.Shares.GT(predelegation.Shares) {
+		if del.Shares.GT(preDelegationChangeData.Shares) {
 			// is bonding
-			diffShares := del.Shares.Sub(predelegation.Shares)
+			diffShares := del.Shares.Sub(preDelegationChangeData.Shares)
 			validator, err := h.k.stakingKeeper.GetValidator(ctx, valAddr)
 			if err != nil {
 				return err
 			}
 			diffTokens := validator.TokensFromSharesTruncated(del.Shares).TruncateInt().
-				Sub(validator.TokensFromSharesTruncated(predelegation.Shares).TruncateInt())
+				Sub(validator.TokensFromSharesTruncated(preDelegationChangeData.Shares).TruncateInt())
 			if err := h.k.SafelyIncreaseTotalLiquidStakedTokens(ctx, diffTokens, true); err != nil {
 				return err
 			}
@@ -108,14 +119,14 @@ func (h Hooks) AfterDelegationModified(ctx context.Context, delAddr sdk.AccAddre
 			if err != nil {
 				return err
 			}
-		} else if del.Shares.LT(predelegation.Shares) {
+		} else if del.Shares.LT(preDelegationChangeData.Shares) {
 			// is unbonding
-			diffShares := predelegation.Shares.Sub(del.Shares)
+			diffShares := preDelegationChangeData.Shares.Sub(del.Shares)
 			validator, err := h.k.stakingKeeper.GetValidator(ctx, valAddr)
 			if err != nil {
 				return err
 			}
-			diffTokens := validator.TokensFromSharesTruncated(predelegation.Shares).TruncateInt().
+			diffTokens := validator.TokensFromSharesTruncated(preDelegationChangeData.Shares).TruncateInt().
 				Sub(validator.TokensFromSharesTruncated(del.Shares).TruncateInt())
 			if err := h.k.DecreaseTotalLiquidStakedTokens(ctx, diffTokens); err != nil {
 				return err
@@ -168,27 +179,26 @@ func (h Hooks) AfterValidatorBeginUnbonding(_ context.Context, _ sdk.ConsAddress
 
 func (h Hooks) BeforeDelegationRemoved(ctx context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) error {
 	if h.k.DelegatorIsLiquidStaker(delAddr) {
-		if predelegation == nil {
-			return types.ErrPreHookIsNil
+		preDelegationChangeData, err := h.k.GetTransientHookDelegationData(ctx)
+		if err != nil || preDelegationChangeData == nil {
+			return sdkerrors.Wrapf(types.ErrPreHookIsNil, "err: %v, transientStoreData is empty, expected non-nil value", err)
 		}
+
 		// reset prehook
-		defer func() { predelegation = nil }()
+		defer func() { _ = h.k.SetTransientHookDelegationData(ctx, preDelegationChangeData) }()
 		// is unbonding.
 		validator, err := h.k.stakingKeeper.GetValidator(ctx, valAddr)
 		if err != nil {
 			return err
 		}
-		tokens := validator.TokensFromSharesTruncated(predelegation.Shares).TruncateInt()
+		tokens := validator.TokensFromSharesTruncated(preDelegationChangeData.Shares).TruncateInt()
 		if err := h.k.DecreaseTotalLiquidStakedTokens(ctx, tokens); err != nil {
 			return err
 		}
-		_, err = h.k.DecreaseValidatorLiquidShares(ctx, valAddr, predelegation.Shares)
+		_, err = h.k.DecreaseValidatorLiquidShares(ctx, valAddr, preDelegationChangeData.Shares)
 		if err != nil {
 			return err
 		}
-
-		// reset prehook
-		predelegation = nil
 	}
 	return nil
 }

--- a/x/liquid/keeper/keeper.go
+++ b/x/liquid/keeper/keeper.go
@@ -5,6 +5,7 @@ import (
 
 	storetypes "cosmossdk.io/core/store"
 	"cosmossdk.io/log"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -15,6 +16,7 @@ import (
 // Keeper of the x/liquid store
 type Keeper struct {
 	storeService  storetypes.KVStoreService
+	tStoreService storetypes.TransientStoreService
 	cdc           codec.BinaryCodec
 	authKeeper    types.AccountKeeper
 	bankKeeper    types.BankKeeper
@@ -27,6 +29,7 @@ type Keeper struct {
 func NewKeeper(
 	cdc codec.BinaryCodec,
 	storeService storetypes.KVStoreService,
+	tStoreService storetypes.TransientStoreService,
 	ak types.AccountKeeper,
 	bk types.BankKeeper,
 	sk types.StakingKeeper,
@@ -40,6 +43,7 @@ func NewKeeper(
 
 	return &Keeper{
 		storeService:  storeService,
+		tStoreService: tStoreService,
 		cdc:           cdc,
 		authKeeper:    ak,
 		bankKeeper:    bk,
@@ -58,4 +62,37 @@ func (k Keeper) Logger(ctx context.Context) log.Logger {
 // GetAuthority returns the x/liquid module's authority.
 func (k Keeper) GetAuthority() string {
 	return k.authority
+}
+
+// GetTransientHookDelegationData retrieves delegation data from the transient store using a predefined key.
+// Returns the delegation and an error if unmarshalling or store retrieval fails.
+func (k Keeper) GetTransientHookDelegationData(ctx context.Context) (*stakingtypes.Delegation, error) {
+	tStore := k.tStoreService.OpenTransientStore(ctx)
+	delBz, err := tStore.Get(types.TransientHookDelegationDataPrefix)
+	if err != nil {
+		return nil, err
+	}
+	var del stakingtypes.Delegation
+	err = k.cdc.Unmarshal(delBz, &del)
+	if err != nil {
+		return nil, err
+	}
+	return &del, nil
+}
+
+// SetTransientHookDelegationData sets delegation data into the transient store using serialized input for temporary storage.
+func (k Keeper) SetTransientHookDelegationData(ctx context.Context, del *stakingtypes.Delegation) error {
+	tStore := k.tStoreService.OpenTransientStore(ctx)
+	delbBz, err := k.cdc.Marshal(del)
+	if err != nil {
+		return err
+	}
+	return tStore.Set(types.TransientHookDelegationDataPrefix, delbBz)
+}
+
+// ResetTransientHookDelegationData clears transient hook delegation data from the transient store for the given context.
+func (k Keeper) ResetTransientHookDelegationData(ctx context.Context) error {
+	tStore := k.tStoreService.OpenTransientStore(ctx)
+	return tStore.Delete(types.TransientHookDelegationDataPrefix)
+
 }

--- a/x/liquid/keeper/keeper.go
+++ b/x/liquid/keeper/keeper.go
@@ -69,7 +69,7 @@ func (k Keeper) GetAuthority() string {
 func (k Keeper) GetTransientHookDelegationData(ctx context.Context) (*stakingtypes.Delegation, error) {
 	tStore := k.tStoreService.OpenTransientStore(ctx)
 	delBz, err := tStore.Get(types.TransientHookDelegationDataPrefix)
-	if err != nil {
+	if err != nil || delBz == nil {
 		return nil, err
 	}
 	var del stakingtypes.Delegation

--- a/x/liquid/keeper/msg_server.go
+++ b/x/liquid/keeper/msg_server.go
@@ -129,14 +129,6 @@ func (k msgServer) TokenizeShares(goCtx context.Context, msg *types.MsgTokenizeS
 		return nil, types.ErrRedelegationInProgress
 	}
 
-	if err := k.SafelyIncreaseTotalLiquidStakedTokens(ctx, msg.Amount.Amount, true); err != nil {
-		return nil, err
-	}
-	_, err = k.SafelyIncreaseValidatorLiquidShares(ctx, valAddr, shares, true)
-	if err != nil {
-		return nil, err
-	}
-
 	recordID := k.GetLastTokenizeShareRecordID(ctx) + 1
 	k.SetLastTokenizeShareRecordID(ctx, recordID)
 
@@ -281,14 +273,6 @@ func (k msgServer) RedeemTokensForShares(goCtx context.Context, msg *types.MsgRe
 	// prevent redemption that returns a 0 amount
 	if tokens.IsZero() {
 		return nil, types.ErrTinyRedemptionAmount
-	}
-
-	if err := k.DecreaseTotalLiquidStakedTokens(ctx, tokens); err != nil {
-		return nil, err
-	}
-	_, err = k.DecreaseValidatorLiquidShares(ctx, valAddr, shares)
-	if err != nil {
-		return nil, err
 	}
 
 	returnAmount, err := k.stakingKeeper.Unbond(ctx, record.GetModuleAddress(), valAddr, shares)

--- a/x/liquid/types/errors.go
+++ b/x/liquid/types/errors.go
@@ -21,4 +21,7 @@ var (
 	ErrNotEnoughBalance                        = errors.Register(ModuleName, 101, "not enough balance")
 	ErrTinyRedemptionAmount                    = errors.Register(ModuleName, 119, "too few tokens to redeem (truncates to zero tokens)")
 	ErrNoValidatorFound                        = errors.Register(ModuleName, 3, "validator does not exist")
+	ErrPreHookIsNotNil                         = errors.Register(ModuleName, 130, "liquid shares hooks, prehook is not nil")
+	ErrPreHookIsNil                            = errors.Register(ModuleName, 131, "liquid shares hooks, prehook is nil")
+	ErrInvalidHookInvocation                   = errors.Register(ModuleName, 132, "liquid shares hooks, shares before and after are same")
 )

--- a/x/liquid/types/keys.go
+++ b/x/liquid/types/keys.go
@@ -19,6 +19,8 @@ const (
 
 	// Prefix for module accounts that custodian tokenized shares
 	TokenizeShareModuleAccountPrefix = "tokenizeshare_"
+
+	TStoreKey = "transient_liquid"
 )
 
 var (
@@ -34,6 +36,8 @@ var (
 	TokenizeSharesLockPrefix           = []byte{0x6} // key for locking tokenize shares
 	TokenizeSharesUnlockQueuePrefix    = []byte{0x7} // key for the queue that unlocks tokenize shares
 	LiquidValidatorPrefix              = []byte{0x8} // key for liquid validator prefix
+
+	TransientHookDelegationDataPrefix = []byte{0x21}
 )
 
 // GetLiquidValidatorKey returns the key of the liquid validator.


### PR DESCRIPTION
Bug:
- lsm spec defined all tokens staked by 32-length addresses as liquid-stakers. (includes - cosmwasm contracts, ica-accounts, other 32-length addresses created by modules) AND tokenized shares by any addresses
- x/liquid only accounts for tokenized shares, and skips stakers using 32-length addresses

Changes:
- removes validator-liquid-shares and total-staked-tokens updation logic from tokenizeShares and RedeemShares msgServer implementation
- adds the updation logic to staking hooks implementation
- adds a transientStorekey to temporarily store delegation (before updation) to figure out change in shares